### PR TITLE
Adding a default image placeholder when image not exists

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || (process.env.PUBLIC_URL +'/placeholder.png')}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />
@@ -49,7 +49,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2 item-footer">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={item.seller.image || (process.env.PUBLIC_URL +'/placeholder.png')}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />


### PR DESCRIPTION
# Description

Fixing a bug that if there is no image there are broken images. Adding a default as a solution

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/8188505/207948024-15af7708-1153-4456-97ac-6337c2204ab6.png">
